### PR TITLE
PHP7.2 & laravel/framework Dependency

### DIFF
--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -11,7 +11,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [7.2, 7.3, 7.4, 8.0, 8.1]
+                php: [7.3, 7.4, 8.0, 8.1]
                 dependency-version: [prefer-lowest, prefer-stable]
                 dev-dependencies: [dev, no-dev]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [7.2, 7.3, 7.4, 8.0, 8.1]
+                php: [7.3, 7.4, 8.0, 8.1]
                 composer-test: [docker-test, docker-test-lowest]
 
         name: PHP ${{ matrix.php }} - ${{ matrix.composer-test }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [7.2, 7.3, 7.4, 8.0, 8.1]
+                php: [7.3, 7.4, 8.0, 8.1]
                 dependency-version: [prefer-lowest, prefer-stable]
 
         name: PHP ${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,8 @@ All notable changes to `healthy` will be documented in this file
 ## 1.1.1 - 2022-03-03
 - optimize composer dependency constraints
 - add use of GitHub actions
+
+
+## 2.0.0 - 2022-03-08
+- cut support for php7.2
+- fix laravel/framework version constraint requiring a version with vulnerabilities

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
-        "laravel/framework": "^7.30.6|>=8.0",
+        "php": ">=7.3",
+        "laravel/framework": ">=8.0",
         "sfneal/controllers": "^2.0|^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "laravel/framework": ">=7.24 <7.29|>=8.0",
+        "laravel/framework": "^7.30.6|>=8.0",
         "sfneal/controllers": "^2.0|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
- cut support for php7.2
- fix laravel/framework version constraint requiring a version with vulnerabilities